### PR TITLE
Add flake.nix to facilitate building and installation of N64Recomp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ RSP microcode can also be recompiled with this tool. Currently there is no suppo
 ## Building
 This project can be built with CMake 3.20 or above and a C++ compiler that supports C++20. This repo uses git submodules, so be sure to clone recursively (`git clone --recurse-submodules`) or initialize submodules recursively after cloning (`git submodule update --init --recursive`). From there, building is identical to any other cmake project, e.g. run `cmake` in the target build folder and point it at the root of this repo, then run `cmake --build .` from that target folder.
 
+## Nix
+If you are using nixos our have [nix installed](https://nixos.org/)
+This project can be built and run using nix flakes, to spawn a shell with both, N64Recomp and RSPRecomp programs available you can perform the command:
+
+`nix shell 'git+https://github.com/Mr-Wiseguy/N64Recomp?submodules=1#N64Recomp`
+
 ## Libraries Used
 * [rabbitizer](https://github.com/Decompollaborate/rabbitizer) for instruction decoding/analysis
 * [ELFIO](https://github.com/serge1/ELFIO) for elf parsing

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715266358,
+        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Tool to statically recompile N64 games into native executables";
+  inputs = {
+    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
+
+    flake-utils.url = github:numtide/flake-utils;
+
+    flake-compat.url = github:edolstra/flake-compat;
+    flake-compat.flake = false;
+  };
+
+  outputs = inputs @ {...}:
+    inputs.flake-utils.lib.eachDefaultSystem
+    (
+      system: let
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+        };
+      in rec {
+        packages = rec {
+          N64Recomp = pkgs.stdenv.mkDerivation {
+            pname = "N64Recomp";
+            version = "0.1.0";
+            src = ./.;
+            nativeBuildInputs = [pkgs.cmake];
+
+            installPhase = ''
+                mkdir -p $out/bin
+                cp N64Recomp $out/bin
+                cp RSPRecomp $out/bin
+            '';
+          };
+          default = N64Recomp;
+        };
+        apps = rec {
+          N64Recomp = {
+            type = "app";
+            program = "${packages.N64Recomp}/bin/N64Recomp";
+          };
+
+          RSPRecomp = {
+            type = "app";
+            program = "${packages.N64Recomp}/bin/RSPRecomp";
+          };
+          default = N64Recomp;
+        };
+      }
+    );
+}


### PR DESCRIPTION
In this PR I add a flake.nix file that it's super useful to install and test this program in computer that have the nix language installed. https://nixos.org/

This allows the following:

- Open a bash session with N64Recomp and RSPRecomp in PATH
nix shell 'git+https://github.com/Mr-Wiseguy/N64Recomp?submodules=1#N64Recomp

- Install on your nix profile
nix profile install 'git+https://github.com/Mr-Wiseguy/N64Recomp?submodules=1#N64Recomp

- Run directly the app
nix run 'git+https://github.com/Mr-Wiseguy/N64Recomp?submodules=1#N64Recomp
nix run 'git+https://github.com/Mr-Wiseguy/N64Recomp?submodules=1#RSPRecomp

And also, since it's a flake, add it to your static configuration for your system.


