### PR TITLE
Implement doubleword multiply and divide, and conversions between doubleword and single/double precision floats

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,10 +141,6 @@ std::unordered_set<std::string> reimplemented_funcs{
     "__osInitialize_kmc",
     "__osInitialize_isv",
     "__osRdbSend",
-    // libgcc math routines (these throw off the recompiler)
-    "__udivdi3",
-    "__divdi3",
-    "__umoddi3",
     // ido math routines
     "__ull_div",
     "__ll_div",

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -386,15 +386,27 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
     case InstrId::cpu_mult:
         print_line("result = S64(S32({}{})) * S64(S32({}{})); lo = S32(result >> 0); hi = S32(result >> 32)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
+    case InstrId::cpu_dmult:
+        print_line("MUL128_S({}{}, {}{}, hi, lo)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        break;
     case InstrId::cpu_multu:
         print_line("result = U64(U32({}{})) * U64(U32({}{})); lo = S32(result >> 0); hi = S32(result >> 32)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        break;
+    case InstrId::cpu_dmultu:
+        print_line("MUL128_U({}{}, {}{}, hi, lo)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_div:
         // Cast to 64-bits before division to prevent artihmetic exception for s32(0x80000000) / -1
         print_line("lo = S32(S64(S32({}{})) / S64(S32({}{}))); hi = S32(S64(S32({}{})) % S64(S32({}{})))", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
+    case InstrId::cpu_ddiv:
+        print_line("lo = S64({}{}) / S64({}{}); hi = S64({}{}) % S64({}{})", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        break;
     case InstrId::cpu_divu:
         print_line("lo = S32(U32({}{}) / U32({}{})); hi = S32(U32({}{}) % U32({}{}))", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        break;
+    case InstrId::cpu_ddivu:
+        print_line("lo = U64({}{}) / U64({}{}); hi = U64({}{}) % U64({}{})", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_mflo:
         print_line("{}{} = lo", ctx_gpr_prefix(rd), rd);
@@ -928,6 +940,28 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
         print_line("CHECK_FR(ctx, {})", fs);
         print_line("NAN_CHECK(ctx->f{}.d)", fs);
         print_line("ctx->f{}.fl = CVT_S_D(ctx->f{}.d)", fd, fs);
+        break;
+    case InstrId::cpu_cvt_d_l:
+        print_line("CHECK_FR(ctx, {})", fd);
+        print_line("CHECK_FR(ctx, {})", fs);
+        print_line("ctx->f{}.d = CVT_D_L(ctx->f{}.u64)", fd, fs);
+        break;
+    case InstrId::cpu_cvt_l_d:
+        print_line("CHECK_FR(ctx, {})", fd);
+        print_line("CHECK_FR(ctx, {})", fs);
+        print_line("NAN_CHECK(ctx->f{}.d)", fs);
+        print_line("ctx->f{}.u64 = CVT_L_D(ctx->f{}.d)", fd, fs);
+        break;
+    case InstrId::cpu_cvt_s_l:
+        print_line("CHECK_FR(ctx, {})", fd);
+        print_line("CHECK_FR(ctx, {})", fs);
+        print_line("ctx->f{}.fl = CVT_S_L(ctx->f{}.u64)", fd, fs);
+        break;
+    case InstrId::cpu_cvt_l_s:
+        print_line("CHECK_FR(ctx, {})", fd);
+        print_line("CHECK_FR(ctx, {})", fs);
+        print_line("NAN_CHECK(ctx->f{}.fl)", fs);
+        print_line("ctx->f{}.u64 = CVT_L_S(ctx->f{}.fl)", fd, fs);
         break;
     case InstrId::cpu_trunc_w_s:
         print_line("CHECK_FR(ctx, {})", fd);

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -387,26 +387,26 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
         print_line("result = S64(S32({}{})) * S64(S32({}{})); lo = S32(result >> 0); hi = S32(result >> 32)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_dmult:
-        print_line("MUL128_S({}{}, {}{}, hi, lo)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        print_line("DMULT(S64({}{}), S64({}{}), &lo, &hi)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_multu:
         print_line("result = U64(U32({}{})) * U64(U32({}{})); lo = S32(result >> 0); hi = S32(result >> 32)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_dmultu:
-        print_line("MUL128_U({}{}, {}{}, hi, lo)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        print_line("DMULTU(U64({}{}), U64({}{}), &lo, &hi)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_div:
         // Cast to 64-bits before division to prevent artihmetic exception for s32(0x80000000) / -1
         print_line("lo = S32(S64(S32({}{})) / S64(S32({}{}))); hi = S32(S64(S32({}{})) % S64(S32({}{})))", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_ddiv:
-        print_line("lo = S64({}{}) / S64({}{}); hi = S64({}{}) % S64({}{})", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        print_line("DDIV(S64({}{}), S64({}{}), &lo, &hi)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_divu:
         print_line("lo = S32(U32({}{}) / U32({}{})); hi = S32(U32({}{}) % U32({}{}))", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_ddivu:
-        print_line("lo = U64({}{}) / U64({}{}); hi = U64({}{}) % U64({}{})", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt, ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
+        print_line("DDIVU(U64({}{}), U64({}{}), &lo, &hi)", ctx_gpr_prefix(rs), rs, ctx_gpr_prefix(rt), rt);
         break;
     case InstrId::cpu_mflo:
         print_line("{}{} = lo", ctx_gpr_prefix(rd), rd);


### PR DESCRIPTION
The IDO math routines can probably be removed from the reimplemented functions list as well?

For reference/verifiability of changes, here is the accompanying `recomp.h` changes
```c
#if defined(__SIZEOF_INT128__)

typedef __int128 int128_t;
typedef unsigned __int128 uint128_t;

static inline void DMULT(int64_t a, int64_t b, int64_t * lo64, int64_t * hi64) {
    int128_t full128 = ((int128_t)a) * ((int128_t)b);

    *hi64 = (int64_t)(full128 >> 64);
    *lo64 = (int64_t)(full128 >> 0);
}

static inline void DMULTU(uint64_t a, uint64_t b, uint64_t * lo64, uint64_t * hi64) {
    uint128_t full128 = ((uint128_t)a) * ((uint128_t)b);

    *hi64 = (uint64_t)(full128 >> 64);
    *lo64 = (uint64_t)(full128 >> 0);
}

#elif defined(_MSC_VER)

#include <intrin.h>
#pragma intrinsic(_mul128)
#pragma intrinsic(_umul128)

static inline void DMULT(int64_t a, int64_t b, int64_t * lo64, int64_t * hi64) {
    *lo64 = _mul128(a, b, hi64);
}

static inline void DMULTU(uint64_t a, uint64_t b, uint64_t * lo64, uint64_t * hi64) {
    *lo64 = _umul128(a, b, hi64);
}

#else
#error "128-bit integer type not found"
#endif


static inline void DDIV(int64_t a, int64_t b, int64_t * quot, int64_t * rem) {
    bool overflow = ((uint64_t)a == 0x8000000000000000ull) && (b == -1ll);
    *quot = overflow ? a : (a / b);
    *rem = overflow ? 0 : (a % b);
}

static inline void DDIVU(uint64_t a, uint64_t b, uint64_t * quot, uint64_t * rem) {
    *quot = a / b;
    *rem = a % b;
}
```
```c
#define CVT_L_D(f) \
    ((int64_t)(f))

#define CVT_D_L(f) \
    ((double)(int64_t)(f))

#define CVT_L_S(f) \
    ((int64_t)(f))

#define CVT_S_L(f) \
    ((float)(int64_t)(f))

```