### PR TITLE
Implement `bal`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1182,6 +1182,7 @@ int main(int argc, char** argv) {
     RabbitizerConfig_Cfg.pseudos.pseudoBeqz = false;
     RabbitizerConfig_Cfg.pseudos.pseudoBnez = false;
     RabbitizerConfig_Cfg.pseudos.pseudoNot = false;
+    RabbitizerConfig_Cfg.pseudos.pseudoBal = false;
 
     std::vector<std::string> relocatable_sections_ordered{};
 

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -638,6 +638,14 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
     case InstrId::cpu_break:
         print_line("do_break({})", instr_vram);
         break;
+    case InstrId::cpu_bgezall:
+        is_branch_likely = true;
+        [[fallthrough]];
+    case InstrId::cpu_bgezal:
+        print_indent();
+        print_branch_condition("if (SIGNED({}{}) >= 0)", ctx_gpr_prefix(rs), rs);
+        print_func_call(instr.getBranchVramGeneric());
+        break;
 
     // Cop1 loads/stores
     case InstrId::cpu_mtc1:

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -643,8 +643,9 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
         [[fallthrough]];
     case InstrId::cpu_bgezal:
         print_indent();
-        print_branch_condition("if (SIGNED({}{}) >= 0)", ctx_gpr_prefix(rs), rs);
+        print_branch_condition("if (SIGNED({}{}) >= 0) {{", ctx_gpr_prefix(rs), rs);
         print_func_call(instr.getBranchVramGeneric());
+        print_line("}}");
         break;
 
     // Cop1 loads/stores


### PR DESCRIPTION
Implements the `bgezal` instruction (and by proxy the `bal` pseudo).

I copied what the branch instructions and `jal` were doing. I think I did it right, but I'm not completely sure.

`bal` is used on drmario