### PR TITLE
Add more `renamed_funcs`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1304,6 +1304,8 @@ int main(int argc, char** argv) {
         "\n"
         "#ifdef __cplusplus\n"
         "extern \"C\" {{\n"
+        "#endif\n"
+        "\n"
     );
 
     std::vector<std::vector<uint32_t>> static_funcs_by_section{ context.sections.size() };
@@ -1501,8 +1503,6 @@ int main(int argc, char** argv) {
         "\n"
         "#ifdef __cplusplus\n"
         "}}\n"
-        "#endif\n"
-        "\n"
         "#endif\n"
     );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -537,13 +537,21 @@ std::unordered_set<std::string> ignored_funcs {
 };
 
 std::unordered_set<std::string> renamed_funcs{
+    // Math
     "sincosf",
     "sinf",
     "cosf",
     "__sinf",
     "__cosf",
+    "asinf",
+    "acosf",
+    "atanf",
+    "atan2f",
+    "tanf",
     "sqrt",
     "sqrtf",
+
+    // Memory
     "memcpy",
     "memset",
     "memmove",
@@ -557,8 +565,12 @@ std::unordered_set<std::string> renamed_funcs{
     "bzero",
     "bcopy",
     "bcmp",
+
+    // long jumps
     "setjmp",
     "longjmp",
+
+    // Math 2
     "ldiv",
     "lldiv",
     "ceil",
@@ -576,17 +588,43 @@ std::unordered_set<std::string> renamed_funcs{
     "roundf",
     "trunc",
     "truncf",
+
+    // printf family
     "vsprintf",
-    "__assert",
-    "malloc",
-    "free",
-    "realloc",
-    "rand",
-    "srand",
-    "random",
     "gcvt",
     "fcvt",
     "ecvt",
+
+    "__assert",
+
+    // allocations
+    "malloc",
+    "free",
+    "realloc",
+    "calloc",
+
+    // rand
+    "rand",
+    "srand",
+    "random",
+
+    // gzip
+    "huft_build",
+    "huft_free",
+    "inflate_codes",
+    "inflate_stored",
+    "inflate_fixed",
+    "inflate_dynamic",
+    "inflate_block",
+    "inflate",
+    "expand_gzip",
+    "auRomDataRead"
+    "data_write",
+    "unzip",
+    "updcrc",
+    "clear_bufs",
+    "fill_inbuf",
+    "flush_window",
 };
 
 bool read_symbols(RecompPort::Context& context, const ELFIO::elfio& elf_file, ELFIO::section* symtab_section, uint32_t entrypoint, bool has_entrypoint, bool use_absolute_symbols) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -505,6 +505,9 @@ std::unordered_set<std::string> ignored_funcs {
     "__divdi3",
     "__udivdi3",
     "__umoddi3",
+    "div64_64",
+    "div64_32",
+    "__moddi3",
     // ido math routines
     "__ll_div",
     "__ll_lshift",
@@ -543,6 +546,7 @@ std::unordered_set<std::string> renamed_funcs{
     "sqrtf",
     "memcpy",
     "memset",
+    "memmove",
     "strcmp",
     "strcat",
     "strcpy",
@@ -562,6 +566,8 @@ std::unordered_set<std::string> renamed_funcs{
     "floor",
     "floorf",
     "fmodf",
+    "fmod",
+    "modf",
     "lround",
     "lroundf",
     "nearbyint",
@@ -575,6 +581,8 @@ std::unordered_set<std::string> renamed_funcs{
     "malloc",
     "free",
     "realloc",
+    "rand",
+    "srand",
 };
 
 bool read_symbols(RecompPort::Context& context, const ELFIO::elfio& elf_file, ELFIO::section* symtab_section, uint32_t entrypoint, bool has_entrypoint, bool use_absolute_symbols) {
@@ -1249,6 +1257,8 @@ int main(int argc, char** argv) {
     std::ofstream func_header_file{ config.output_func_path / "funcs.h" };
 
     fmt::print(func_header_file,
+        "#ifndef __RECOMPED_FUNCS_H__\n"
+        "#define __RECOMPED_FUNCS_H__\n"
         "#include \"recomp.h\"\n"
         "\n"
         "#ifdef __cplusplus\n"
@@ -1452,6 +1462,8 @@ int main(int argc, char** argv) {
         "\n"
         "#ifdef __cplusplus\n"
         "}}\n"
+        "#endif\n"
+        "\n"
         "#endif\n"
     );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1300,14 +1300,10 @@ int main(int argc, char** argv) {
     std::ofstream func_header_file{ config.output_func_path / "funcs.h" };
 
     fmt::print(func_header_file,
-        "#ifndef __RECOMPED_FUNCS_H__\n"
-        "#define __RECOMPED_FUNCS_H__\n"
         "#include \"recomp.h\"\n"
         "\n"
         "#ifdef __cplusplus\n"
         "extern \"C\" {{\n"
-        "#endif\n"
-        "\n"
     );
 
     std::vector<std::vector<uint32_t>> static_funcs_by_section{ context.sections.size() };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -583,6 +583,10 @@ std::unordered_set<std::string> renamed_funcs{
     "realloc",
     "rand",
     "srand",
+    "random",
+    "gcvt",
+    "fcvt",
+    "ecvt",
 };
 
 bool read_symbols(RecompPort::Context& context, const ELFIO::elfio& elf_file, ELFIO::section* symtab_section, uint32_t entrypoint, bool has_entrypoint, bool use_absolute_symbols) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -555,6 +555,7 @@ std::unordered_set<std::string> renamed_funcs{
     "memcpy",
     "memset",
     "memmove",
+    "memcmp",
     "strcmp",
     "strcat",
     "strcpy",

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -1067,6 +1067,7 @@ bool RecompPort::recompile_function(const RecompPort::Context& context, const Re
         // Write the file header
         fmt::print(output_file,
             "#include \"recomp.h\"\n"
+            "#include \"funcs.h\"\n"
             "#include \"disable_warnings.h\"\n"
             "\n");
     }

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -1067,7 +1067,6 @@ bool RecompPort::recompile_function(const RecompPort::Context& context, const Re
         // Write the file header
         fmt::print(output_file,
             "#include \"recomp.h\"\n"
-            "#include \"funcs.h\"\n"
             "#include \"disable_warnings.h\"\n"
             "\n");
     }


### PR DESCRIPTION
Add more standard functions that may appear  in other recomp projects.
I also added gzip functions to the list, not sure if those are common enough to guarantee to be part of this list. I can remove them if preferred.

I also added `#include "funcs.h"` to the generated C files to minimize the wall of warnings for using undeclared functions.